### PR TITLE
Make interactive app work on Docker-less hosts too

### DIFF
--- a/pkg/app/master/command/cliprompt.go
+++ b/pkg/app/master/command/cliprompt.go
@@ -19,11 +19,7 @@ import (
 
 	"github.com/mintoolkit/mint/pkg/app"
 	"github.com/mintoolkit/mint/pkg/app/master/config"
-	"github.com/mintoolkit/mint/pkg/docker/dockerclient"
 	"github.com/mintoolkit/mint/pkg/docker/dockerutil"
-	"github.com/mintoolkit/mint/pkg/util/errutil"
-	"github.com/mintoolkit/mint/pkg/util/fsutil"
-	"github.com/mintoolkit/mint/pkg/version"
 )
 
 type InteractiveApp struct {
@@ -40,20 +36,6 @@ func NewInteractiveApp(app *cli.App, gparams *GenericParams) *InteractiveApp {
 			IgnoreCase: true,
 		},
 	}
-
-	client, err := dockerclient.New(gparams.ClientConfig)
-	if err == dockerclient.ErrNoDockerInfo {
-		exitMsg := "missing Docker connection info"
-		if gparams.InContainer && gparams.IsDSImage {
-			exitMsg = "make sure to pass the Docker connect parameters to the mint app container"
-		}
-		fmt.Printf("mint: info=docker.connect.error message='%s'\n", exitMsg)
-		fmt.Printf("mint: state=exited version=%s location='%s'\n", version.Current(), fsutil.ExeDir())
-		os.Exit(-777)
-	}
-	errutil.FailOn(err)
-
-	ia.dclient = client
 
 	ia.appPrompt = prompt.New(
 		ia.execute,

--- a/pkg/app/master/command/debug/handle_containerd_runtime.go
+++ b/pkg/app/master/command/debug/handle_containerd_runtime.go
@@ -3,6 +3,8 @@ package debug
 import (
 	"fmt"
 	"os"
+	"strings"
+
 	//"time"
 	"context"
 	"os/signal"
@@ -249,7 +251,7 @@ func HandleContainerdRuntime(
 
 	//TODO: pull only if the image doesn't exist
 	//TODO: expand the image path for short docker image paths
-	if !strings.Contains(commandParams.DebugContainerImage,"/") {
+	if !strings.Contains(commandParams.DebugContainerImage, "/") {
 		//a hacky way to ensure full paths for containerd :)
 		commandParams.DebugContainerImage = fmt.Sprintf("docker.io/library/%s", commandParams.DebugContainerImage)
 	}

--- a/scripts/src.build.quick.sh
+++ b/scripts/src.build.quick.sh
@@ -10,7 +10,7 @@ BUILD_TIME="$(date -u '+%Y-%m-%d_%I:%M:%S%p')"
 TAG="current"
 REVISION="current"
 if hash git 2>/dev/null && [ -e $BDIR/.git ]; then
-  TAG="$(git describe --tags)"
+  TAG="$(git describe --tags --always)"
   REVISION="$(git rev-parse HEAD)"
 fi
 


### PR DESCRIPTION
The removed client initialization seemed redundant anyway because the dockerutil calls can work with nil clients, too.
