### PR TITLE
Use the custom entrypoint and cmd when they are not empty

### DIFF
--- a/pkg/app/master/command/debug/handle_containerd_runtime.go
+++ b/pkg/app/master/command/debug/handle_containerd_runtime.go
@@ -250,7 +250,7 @@ func HandleContainerdRuntime(
 		}
 
 		commandParams.Cmd = []string{shellConfig}
-	} else {
+	} else if len(commandParams.Entrypoint) == 0 && len(commandParams.Cmd) == 0 {
 		commandParams.Entrypoint = ShellCommandPrefix(commandParams.DebugContainerImage)
 		if len(commandParams.Cmd) == 0 {
 			commandParams.Cmd = []string{defaultShellName}

--- a/pkg/app/master/command/debug/handle_docker_runtime.go
+++ b/pkg/app/master/command/debug/handle_docker_runtime.go
@@ -230,7 +230,7 @@ func HandleDockerRuntime(
 		}
 
 		commandParams.Cmd = []string{shellConfig}
-	} else {
+	} else if len(commandParams.Entrypoint) == 0 && len(commandParams.Cmd) == 0 {
 		commandParams.Entrypoint = ShellCommandPrefix(commandParams.DebugContainerImage)
 		if len(commandParams.Cmd) == 0 {
 			commandParams.Cmd = []string{defaultShellName}

--- a/pkg/app/master/command/debug/handle_kubernetes_runtime.go
+++ b/pkg/app/master/command/debug/handle_kubernetes_runtime.go
@@ -425,7 +425,7 @@ func HandleKubernetesRuntime(
 		}
 
 		commandParams.Cmd = []string{shellConfig}
-	} else {
+	} else if len(commandParams.Entrypoint) == 0 && len(commandParams.Cmd) == 0 {
 		commandParams.Entrypoint = ShellCommandPrefix(commandParams.DebugContainerImage)
 		if len(commandParams.Cmd) == 0 {
 			commandParams.Cmd = []string{defaultShellName}

--- a/pkg/app/master/command/debug/handle_podman_runtime.go
+++ b/pkg/app/master/command/debug/handle_podman_runtime.go
@@ -432,7 +432,7 @@ func HandlePodmanRuntime(
 		}
 
 		commandParams.Cmd = []string{shellConfig}
-	} else {
+	} else if len(commandParams.Entrypoint) == 0 && len(commandParams.Cmd) == 0 {
 		commandParams.Entrypoint = ShellCommandPrefix(commandParams.DebugContainerImage)
 		if len(commandParams.Cmd) == 0 {
 			commandParams.Cmd = []string{defaultShellName}


### PR DESCRIPTION
Fixes
==================================================================

I find the custom entrypoint doesn't work, the reason is the entrypoint and cmd are forcely rewritten after checked code

What
===============


Why
===============


How Tested
===============




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced handling of runtime configurations to ensure proper initialization of `Entrypoint` and `Cmd` settings across various container platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->