### PR TITLE
Remove the return from the the image OnCommand handler

### DIFF
--- a/pkg/app/execontext.go
+++ b/pkg/app/execontext.go
@@ -107,9 +107,15 @@ func (ref *ExecutionContext) exit(exitCode int) {
 func NewExecutionContext(
 	cmdName string,
 	quiet bool,
-	outputFormat string) *ExecutionContext {
+	outputFormat string,
+	dataChannels ...map[string]chan interface{}) *ExecutionContext {
+	var chs map[string]chan interface{}
+	if len(dataChannels) > 0 {
+		chs = dataChannels[0]
+	}
+
 	ref := &ExecutionContext{
-		Out: NewOutput(cmdName, quiet, outputFormat),
+		Out: NewOutput(cmdName, quiet, outputFormat, chs),
 	}
 
 	return ref
@@ -119,13 +125,15 @@ type Output struct {
 	CmdName      string
 	Quiet        bool
 	OutputFormat string
+	DataChannels map[string]chan interface{}
 }
 
-func NewOutput(cmdName string, quiet bool, outputFormat string) *Output {
+func NewOutput(cmdName string, quiet bool, outputFormat string, channels map[string]chan interface{}) *Output {
 	ref := &Output{
 		CmdName:      cmdName,
 		Quiet:        quiet,
 		OutputFormat: outputFormat,
+		DataChannels: channels,
 	}
 
 	return ref

--- a/pkg/app/master/command/images/cli.go
+++ b/pkg/app/master/command/images/cli.go
@@ -55,7 +55,7 @@ var CLI = &cli.Command{
 			quietLogs,
 			gcvalues.OutputFormat)
 
-		OnCommand(xc, gcvalues, cparams, nil)
+		OnCommand(xc, gcvalues, cparams)
 		return nil
 	},
 }

--- a/pkg/app/master/command/images/cli.go
+++ b/pkg/app/master/command/images/cli.go
@@ -55,7 +55,7 @@ var CLI = &cli.Command{
 			quietLogs,
 			gcvalues.OutputFormat)
 
-		OnCommand(xc, gcvalues, cparams)
+		OnCommand(xc, gcvalues, cparams, nil)
 		return nil
 	},
 }

--- a/pkg/app/master/command/images/handler.go
+++ b/pkg/app/master/command/images/handler.go
@@ -33,7 +33,9 @@ type ovars = app.OutVars
 func OnCommand(
 	xc *app.ExecutionContext,
 	gparams *command.GenericParams,
-	cparams *CommandParams) map[string]crt.BasicImageInfo {
+	cparams *CommandParams,
+	dataCh ImagesCh,
+) {
 	const cmdName = Name
 
 	logger := log.WithFields(log.Fields{"app": appName, "cmd": cmdName})
@@ -43,6 +45,7 @@ func OnCommand(
 
 	cmdReport.State = cmd.StateStarted
 
+	// We will want to communicate this completed state to the TUI.
 	xc.Out.State(cmd.StateStarted)
 	rr := command.ResolveAutoRuntime(cparams.Runtime)
 	if rr != cparams.Runtime {
@@ -131,17 +134,15 @@ func OnCommand(
 	if cparams.TUI { // `images --tui`
 		initialTUI := InitialTUI(images, true)
 		tui.RunTUI(initialTUI, true)
-		return nil
 	} else if cparams.GlobalTUI { // `tui` -> `i`
-		return images
+		dataCh <- images
+		close(dataCh)
 	} else if xc.Out.Quiet {
 		if xc.Out.OutputFormat == command.OutputFormatJSON {
 			fmt.Printf("%s\n", jsonutil.ToPretty(images))
-			return nil
 		}
 
 		printImagesTable(images)
-		return nil
 	} else {
 		xc.Out.Info("image.list", ovars{"count": len(images)})
 		for name, info := range images {
@@ -156,7 +157,10 @@ func OnCommand(
 		}
 	}
 
+	// We will want to communicate this completed state to the TUI.
 	xc.Out.State("completed")
+	// Upon hitting "completed", this is when we could pass the 'complete' images data
+	// to the TUI.
 	cmdReport.State = cmd.StateCompleted
 	xc.Out.State("done")
 
@@ -170,7 +174,6 @@ func OnCommand(
 				"file": cmdReport.ReportLocation(),
 			})
 	}
-	return nil
 }
 
 func printImagesTable(images map[string]crt.BasicImageInfo) {

--- a/pkg/app/master/command/images/handler.go
+++ b/pkg/app/master/command/images/handler.go
@@ -34,7 +34,6 @@ func OnCommand(
 	xc *app.ExecutionContext,
 	gparams *command.GenericParams,
 	cparams *CommandParams,
-	dataCh ImagesCh,
 ) {
 	const cmdName = Name
 
@@ -135,8 +134,10 @@ func OnCommand(
 		initialTUI := InitialTUI(images, true)
 		tui.RunTUI(initialTUI, true)
 	} else if cparams.GlobalTUI { // `tui` -> `i`
-		dataCh <- images
-		close(dataCh)
+		// TODO - create a central store for the lookup key.
+		// As this key needs to be the same on the sender and the receiver.
+		xc.Out.DataChannels["images"] <- images
+		close(xc.Out.DataChannels["images"])
 	} else if xc.Out.Quiet {
 		if xc.Out.OutputFormat == command.OutputFormatJSON {
 			fmt.Printf("%s\n", jsonutil.ToPretty(images))

--- a/pkg/app/master/command/images/model.go
+++ b/pkg/app/master/command/images/model.go
@@ -27,9 +27,6 @@ type TUI struct {
 	loading    bool
 }
 
-// ImagesCh is a channel type used to pass data from the command handler to the TUI.
-type ImagesCh chan map[string]crt.BasicImageInfo
-
 // Styles - move to `common`
 const (
 	gray      = lipgloss.Color("#737373")

--- a/pkg/app/master/command/images/model.go
+++ b/pkg/app/master/command/images/model.go
@@ -27,6 +27,9 @@ type TUI struct {
 	loading    bool
 }
 
+// ImagesCh is a channel type used to pass data from the command handler to the TUI.
+type ImagesCh chan map[string]crt.BasicImageInfo
+
 // Styles - move to `common`
 const (
 	gray      = lipgloss.Color("#737373")
@@ -125,7 +128,9 @@ func (m TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return nil, nil
 		}
 
-		images := OnCommand(xc, gcValue, cparams)
+		imagesCh := make(ImagesCh)
+		go OnCommand(xc, gcValue, cparams, imagesCh)
+		images := <-imagesCh
 		m.table = generateTable(images)
 		return m, nil
 	case tea.WindowSizeMsg:


### PR DESCRIPTION
What
===============
- Add a variadidic argument to the NewExecutionContext function
- In the images TUI model, receive the images data via channel passed to the ExecutionContext

Why
===============
- Leave OnCommand as I/O

How Tested
===============
- `mint tui` -> `i`
- `mint images`
- `mint debug`

## Open Question
- Is using a map[string] chan interface{} the best path?
  - both on the path of using a map string based lookup to support different channels depending on the command context (debug versus images)
  -  and on the path of using an interface, with a typecast being performed by the receiver (which should be the `Update` for each TUI

