### PR TITLE
Add nil check for current docker context

### DIFF
--- a/pkg/crt/docker/dockerclient/client.go
+++ b/pkg/crt/docker/dockerclient/client.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/mintoolkit/mint/pkg/app/master/config"
@@ -210,8 +210,14 @@ func New(config *config.DockerClient) (*docker.Client, error) {
 	//so we need to lookup the context first to extract its connection info
 	var currentDockerContext string
 	if dcf, err := ReadConfigFile(ConfigFilePath()); err == nil {
-		currentDockerContext = dcf.CurrentContext
-		log.Debugf("dockerclient.New: currentDockerContext - '%s'", currentDockerContext)
+		if dcf == nil {
+			log.Debug("dockerclient.New: No config file.")
+		} else {
+			// Handle the case where CurrentContext is empty
+			// For example, set a default context or log a warning
+			currentDockerContext = dcf.CurrentContext
+			log.Debugf("dockerclient.New: currentDockerContext - '%s'", currentDockerContext)
+		}
 	} else {
 		log.Debugf("dockerclient.New: ReadConfigFile error - %v", err)
 	}

--- a/pkg/crt/docker/dockerclient/client.go
+++ b/pkg/crt/docker/dockerclient/client.go
@@ -213,8 +213,6 @@ func New(config *config.DockerClient) (*docker.Client, error) {
 		if dcf == nil {
 			log.Debug("dockerclient.New: No config file.")
 		} else {
-			// Handle the case where CurrentContext is empty
-			// For example, set a default context or log a warning
 			currentDockerContext = dcf.CurrentContext
 			log.Debugf("dockerclient.New: currentDockerContext - '%s'", currentDockerContext)
 		}


### PR DESCRIPTION
What
===============
- Remove assumption that user system has a docker config file

Why
===============
- Prevent panic on invocation of `mint images`

## Initial Bug Reproduction Steps
- On latest master, invoke `make build`
- Have a fresh install of docker on LTS Ubuntu 22.04 - resulting on no user configured options for docker.
![image](https://github.com/user-attachments/assets/336107e3-27f3-4a5b-bced-b961bd1bc196)

The panic:
![image](https://github.com/user-attachments/assets/0adfe15e-994f-412b-a348-ad20b4175ae5)


How Tested
===============
- `make build`
- mint images --runtime=docker
- Confirm you get no panic

