### PR TITLE
Support tui mode for docker session

### DIFF
--- a/pkg/app/master/command/debug/cli.go
+++ b/pkg/app/master/command/debug/cli.go
@@ -32,7 +32,7 @@ type Volume struct {
 }
 
 type CommandParams struct {
-	KubeComm *KubernetesHandlerComm
+	RuntimeCommunicator *RuntimeCommunicator
 	/// the runtime environment type
 	Runtime string
 	/// the running container which we want to attach to

--- a/pkg/app/master/command/debug/handle_kubernetes_runtime.go
+++ b/pkg/app/master/command/debug/handle_kubernetes_runtime.go
@@ -819,8 +819,8 @@ func HandleKubernetesRuntime(
 	fmt.Printf("\n")
 	//note: blocks until done streaming or failure...
 	if commandParams.TUI {
-		// TODO - move KubeComm off of command params
-		reader := &KubeReader{inputChan: commandParams.KubeComm.InputChan}
+		// TODO - move RuntimeCommunicator off of command params
+		reader := &TUIReader{inputChan: commandParams.RuntimeCommunicator.InputChan}
 		err = attach.StreamWithContext(
 			ctx,
 			remotecommand.StreamOptions{
@@ -862,16 +862,16 @@ func HandleKubernetesRuntime(
 // as per the comment in `debug/tui.go`.
 // An InputReader usable by Docker, Podman, Kubernetes, and Containerd
 // will be added to this directory.
-type KubeReader struct {
+type TUIReader struct {
 	inputChan chan InputKey
 }
 
-func (kr *KubeReader) Read(p []byte) (n int, err error) {
-	inputKey, ok := <-kr.inputChan
+func (tuiReader *TUIReader) Read(p []byte) (n int, err error) {
+	inputKey, ok := <-tuiReader.inputChan
 	if !ok {
 		return 0, io.EOF
 	}
-	log.Debugf("KubeReader received inputKey %v", inputKey)
+	log.Debugf("TUIReader received inputKey %v", inputKey)
 	switch inputKey.Special {
 	case NotSpecial:
 		p[0] = byte(inputKey.Rune)

--- a/pkg/app/master/container/execution.go
+++ b/pkg/app/master/container/execution.go
@@ -530,11 +530,18 @@ func (ref *Execution) monitorSysExitSync() {
 }
 
 func (ref *Execution) startTerminal() {
-	r, w := io.Pipe()
-	go io.Copy(w, os.Stdin)
+	var input io.Reader
+	if ref.options.IO.Input == nil {
+		r, w := io.Pipe()
+		input = r
+		go io.Copy(w, os.Stdin)
+	} else {
+		input = ref.options.IO.Input
+	}
+
 	options := dockerapi.AttachToContainerOptions{
 		Container:    ref.ContainerID,
-		InputStream:  r,
+		InputStream:  input,
 		OutputStream: os.Stdout,
 		ErrorStream:  os.Stderr,
 		Stdin:        true,


### PR DESCRIPTION
What
===============
- Add proof of concept for tui driven debugging of a docker container 

Why
===============
- Support input parsing and keypress forwarding for tui driven docker debug session 
- Wanted to stand up this MR for feedback / criticism of the input stream modifications for executions.

How Tested
===============
- User can start a docker driven debug session with or without the tui
- User can connect to an existing session started via the tui.
[Screencast from 2024-11-04 14-27-24.webm](https://github.com/user-attachments/assets/0236d031-9c50-4a88-94b6-eeb02adc7fce)


## Follow Up
- TUI should provide UI feedback after a user has `exited` a debug session.
- Unhardcoding of debug docker specific controls.

## Additional Observation
- docker list sessions -> does not display the target for the running session
- k8s list sessions -> does display target for running sessions.
```

/bin/linux/mint debug --runtime=docker --list-sessions

evan@evan-Precision-5550:~/projects/mint$ ./bin/linux/mint debug --runtime=docker --list-sessions
cmd=debug state=started
cmd=debug info=cmd.input.params runtime='docker' target='' debug-image='busybox@sha256:05a79c7279f71f86a2a0d05eb72fcb56ea36139150f0a75cd87e80a4272e4e39' gid='-1' fallback-to-target-user='true' entrypoint='[]' cmd='[]' terminal='true' run-as-target-shell='true' uid='-1' 
cmd=debug state=action.list_sessions target= 
cmd=debug info=debug.session.count total='1' running='1' waiting='0' terminated='0' 
cmd=debug info=debug.session target='' name='mint-debugger-13b69f3885f133ce9562814e3c4717931efc7718' image='busybox@sha256:05a79c7279f71f86a2a0d05eb72fcb56ea36139150f0a75cd87e80a4272e4e39' state='RUNNING' start.time='2024-11-04 10:50:16 -0500 EST' 
cmd=debug state=completed
cmd=debug state=done```