### PR TITLE
List all k8s debuggable containers

### DIFF
--- a/pkg/system/syscalls_armf32.go
+++ b/pkg/system/syscalls_armf32.go
@@ -7,6 +7,7 @@ const (
 	SyscallArmMaxNum32    = 462
 	SyscallArmLastName32  = "mseal"
 )
+
 // https://github.com/torvalds/linux/blob/master/arch/arm64/tools/syscall_32.tbl , https://github.com/torvalds/linux/blob/master/arch/arm/tools/syscall.tbl
 var syscallNumTableArmFamily32 = map[uint32]string{
 	0:   "restart_syscall",

--- a/pkg/system/syscalls_armf64.go
+++ b/pkg/system/syscalls_armf64.go
@@ -7,6 +7,7 @@ const (
 	SyscallArmMaxNum64      = 462
 	SyscallArmLastName64    = "mseal"
 )
+
 // https://github.com/torvalds/linux/blob/master/scripts/syscall.tbl
 var syscallNumTableArmFamily64 = map[uint32]string{
 	0:   "io_setup",
@@ -289,7 +290,6 @@ var syscallNumTableArmFamily64 = map[uint32]string{
 	292: "io_pgetevents",
 	293: "rseq",
 	294: "kexec_file_load",
-
 
 	424: "pidfd_send_signal",
 	425: "io_uring_setup",

--- a/pkg/system/syscalls_x86f32.go
+++ b/pkg/system/syscalls_x86f32.go
@@ -4,6 +4,7 @@ const (
 	SyscallX86MaxNum32   = 462
 	SyscallX86LastName32 = "mseal"
 )
+
 // https://github.com/torvalds/linux/blob/master/arch/x86/entry/syscalls/syscall_32.tbl
 // line numbers are aligned with the syscall number (-10)
 var syscallNumTableX86Family32 = [...]string{
@@ -442,34 +443,34 @@ var syscallNumTableX86Family32 = [...]string{
 	"fsmount",
 	"fspick",
 	"pidfd_open",
-	"clone3", // 435
-	"close_range", // 436
-	"openat2", // 437
-	"pidfd_getfd", // 438
-	"faccessat2", // 439
-	"process_madvise", // 440
-	"epoll_pwait2", // 441
-	"mount_setattr", // 442
-	"quotactl_fd", // 443
+	"clone3",                  // 435
+	"close_range",             // 436
+	"openat2",                 // 437
+	"pidfd_getfd",             // 438
+	"faccessat2",              // 439
+	"process_madvise",         // 440
+	"epoll_pwait2",            // 441
+	"mount_setattr",           // 442
+	"quotactl_fd",             // 443
 	"landlock_create_ruleset", // 444
-	"landlock_add_rule", // 445
-	"landlock_restrict_self", // 446
-	"memfd_secret", // 447
-	"process_mrelease", // 448
-	"futex_waitv", // 449
+	"landlock_add_rule",       // 445
+	"landlock_restrict_self",  // 446
+	"memfd_secret",            // 447
+	"process_mrelease",        // 448
+	"futex_waitv",             // 449
 	"set_mempolicy_home_node", // 450
-	"cachestat", // 451
-	"fchmodat2", // 452
-	"map_shadow_stack", // 453
-	"futex_wake", // 454
-	"futex_wait", // 455
-	"futex_requeue", // 456
-	"statmount", // 457
-	"listmount", // 458
-	"lsm_get_self_attr", // 459
-	"lsm_set_self_attr", // 460
-	"lsm_list_modules", // 461
-	"mseal", // 462
+	"cachestat",               // 451
+	"fchmodat2",               // 452
+	"map_shadow_stack",        // 453
+	"futex_wake",              // 454
+	"futex_wait",              // 455
+	"futex_requeue",           // 456
+	"statmount",               // 457
+	"listmount",               // 458
+	"lsm_get_self_attr",       // 459
+	"lsm_set_self_attr",       // 460
+	"lsm_list_modules",        // 461
+	"mseal",                   // 462
 }
 
 func callNameX86Family32(num uint32) string {

--- a/pkg/system/syscalls_x86f64.go
+++ b/pkg/system/syscalls_x86f64.go
@@ -4,6 +4,7 @@ const (
 	SyscallX86MaxNum64   = 462
 	SyscallX86LastName64 = "mseal"
 )
+
 // https://github.com/torvalds/linux/blob/master/arch/x86/entry/syscalls/syscall_64.tbl , https://github.com/torvalds/linux/blob/master/scripts/syscall.tbl
 // line numbers are aligned with the syscall number (-10)
 var syscallNumTableX86Family64 = [...]string{
@@ -341,7 +342,7 @@ var syscallNumTableX86Family64 = [...]string{
 	"pkey_free",
 	"statx",
 	"io_pgetevents",
-	"rseq", // 334
+	"rseq",      // 334
 	"uretprobe", // 335
 	"reserved.336",
 	"reserved.337",
@@ -441,35 +442,35 @@ var syscallNumTableX86Family64 = [...]string{
 	"fsconfig",
 	"fsmount",
 	"fspick",
-	"pidfd_open", // 434
-	"clone3", // 435
-	"close_range", // 436
-	"openat2", // 437
-	"pidfd_getfd", // 438
-	"faccessat2", // 439
-	"process_madvise", // 440
-	"epoll_pwait2", // 441
-	"mount_setattr", // 442
-	"quotactl_fd", // 443
+	"pidfd_open",              // 434
+	"clone3",                  // 435
+	"close_range",             // 436
+	"openat2",                 // 437
+	"pidfd_getfd",             // 438
+	"faccessat2",              // 439
+	"process_madvise",         // 440
+	"epoll_pwait2",            // 441
+	"mount_setattr",           // 442
+	"quotactl_fd",             // 443
 	"landlock_create_ruleset", // 444
-	"landlock_add_rule", // 445
-	"landlock_restrict_self", // 446
-	"memfd_secret", // 447
-	"process_mrelease", // 448
-	"futex_waitv", // 449
+	"landlock_add_rule",       // 445
+	"landlock_restrict_self",  // 446
+	"memfd_secret",            // 447
+	"process_mrelease",        // 448
+	"futex_waitv",             // 449
 	"set_mempolicy_home_node", // 450
-	"cachestat", // 451
-	"fchmodat2", // 452
-	"map_shadow_stack", // 453
-	"futex_wake", // 454
-	"futex_wait", // 455
-	"futex_requeue", // 456
-	"statmount", // 457
-	"listmount", // 458
-	"lsm_get_self_attr", // 459
-	"lsm_set_self_attr", // 460
-	"lsm_list_modules", // 461
-	"mseal", // 462
+	"cachestat",               // 451
+	"fchmodat2",               // 452
+	"map_shadow_stack",        // 453
+	"futex_wake",              // 454
+	"futex_wait",              // 455
+	"futex_requeue",           // 456
+	"statmount",               // 457
+	"listmount",               // 458
+	"lsm_get_self_attr",       // 459
+	"lsm_set_self_attr",       // 460
+	"lsm_list_modules",        // 461
+	"mseal",                   // 462
 }
 
 func callNameX86Family64(num uint32) string {


### PR DESCRIPTION
What
===============
- User can list debuggable container across k8s pods
- Runs `make fmt` against syscall files

Why
===============
- This is a precursor step to pick which container to debug within the TUI. Also valuable in its own right.


How Tested
===============

[Screencast from 2024-11-07 15-20-10.webm](https://github.com/user-attachments/assets/3eea4283-1492-4f5b-9a4a-625ec3aaedf9)

