### PR TITLE
Print os.Args prior to exiting.

### DIFF
--- a/pkg/app/execontext.go
+++ b/pkg/app/execontext.go
@@ -23,6 +23,7 @@ const (
 
 type ExecutionContext struct {
 	Out             *Output
+	Args            []string
 	cleanupHandlers []func()
 }
 
@@ -98,7 +99,9 @@ func (ref *ExecutionContext) exit(exitCode int) {
 		ref.Out.Info("exit", OutVars{
 			"code":     exitCode,
 			"version":  v.Current(),
-			"location": fsutil.ExeDir()})
+			"location": fsutil.ExeDir(),
+			"args":     os.Args})
+
 	}
 
 	ShowCommunityInfo(ref.Out.OutputFormat)
@@ -116,7 +119,8 @@ func NewExecutionContext(
 	}
 
 	ref := &ExecutionContext{
-		Out: NewOutput(cmdName, quiet, outputFormat, chs),
+		Out:  NewOutput(cmdName, quiet, outputFormat, chs),
+		Args: os.Args,
 	}
 
 	return ref


### PR DESCRIPTION
[Fixes-70](https://github.com/docker-slim/docker-slim/issues/70)
==================================================================

What
===============
Extends the `ExecutionContext struct` with an `Args` field; upon creating new `ExecutionContext` reference, `os.Args` are persisted in the new field.


Why
===============
suggested by @kcq 


How Tested
===============
first `make test`, then `make build` and locally executed:
```bash
$ cd dist_linux/
$ ./mint --debug
>>> debug --runtime k8s --namespace kube-system --pod storage-provisioner --target storage-provisioner --debug-image busybox@sha256:05a79c7279f71f86a2a0d05eb72fcb56ea36139150f0a75cd87e80a4272e4e39
...
cmd=debug info=exit code='-1' version='linux/amd64|Aurora|69654ca1|69654ca16416b7d389380a67914e36644ed71ca5|2025-01-30_04:20:59' location='/home/ernst/Projekte/mint/dist_linux' args='[./mint --debug]'
```
As can be seen, last line prints `args='[./mint --debug]'`.


