### PR TITLE
Add global flag '--help/-h'.

### DIFF
--- a/pkg/app/master/cli_test.go
+++ b/pkg/app/master/cli_test.go
@@ -1,0 +1,22 @@
+package app
+
+import (
+	"github.com/mintoolkit/mint/pkg/app/master/signals"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCLI(t *testing.T) {
+	signals.InitHandlers()
+	cli := newCLI()
+
+	runArgs := [][]string{
+		{"mint", "--version"},
+		{"mint", "-v"},
+		{"mint", "help"},
+		{"mint", "-h"},
+	}
+	for _, args := range runArgs {
+		require.NoError(t, cli.Run(args))
+	}
+}

--- a/pkg/app/master/command/cliflags.go
+++ b/pkg/app/master/command/cliflags.go
@@ -38,6 +38,7 @@ const (
 	FlagCRTIOInactivityTimeout   = "crt-io-inactivity-timeout"
 	FlagCRTSaveInactivityTimeout = "crt-save-inactivity-timeout"
 	FlagCRTCopyInactivityTimeout = "crt-copy-inactivity-timeout"
+	FlagHelp                     = "help"
 )
 
 const (
@@ -71,6 +72,7 @@ const (
 	FlagCRTIOInactivityTimeoutUsage   = "CRT I/O general inactivity timeout"
 	FlagCRTSaveInactivityTimeoutUsage = "CRT save image operation inactivity timeout (overrides the general I/O timeout)"
 	FlagCRTCopyInactivityTimeoutUsage = "CRT copy from container operation inactivity timeout (overrides the general I/O timeout)"
+	FlagHelpUsage                     = "Show help info"
 )
 
 // Shared command flag names
@@ -432,6 +434,11 @@ func GlobalFlags() []cli.Flag {
 			Value:   0,
 			Usage:   FlagCRTCopyInactivityTimeoutUsage,
 			EnvVars: []string{"DSLIM_CRT_COPY_INACTIVITY_TIMEOUT"},
+		},
+		&cli.BoolFlag{
+			Name:    FlagHelp,
+			Aliases: []string{"h"},
+			Usage:   FlagHelpUsage,
 		},
 		&cli.StringFlag{
 			Name:  FlagStatePath,


### PR DESCRIPTION
[Fixes-71](https://github.com/mintoolkit/mint/issues/71)
==================================================================

What
===============
Defines a global `--help/-h` flag.

Why
===============
Currently, `mint h` and `mint help` are implemented to show the help info. When using `mint -h` or `mint --help`, the help message is only shown due to the fact that `--help` is actually not supported, and this is highlighted by a `FATAL` error message.

How Tested
===============
- built and run locally
- added a `unittest` to ensure that `--help/-h` behaves in the same error-free manner as `--verbose/-v`.