### PR TITLE
📖 Add guided install reference for KubeStellar Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ docker pull mintoolkit/mint
 
 See the [RUNNING CONTAINERIZED](#running-containerized) section for more usage info.
 
+### Guided Install via KubeStellar Console
+
+[KubeStellar Console](https://console.kubestellar.io) offers a [guided installation mission for Mint](https://console.kubestellar.io/missions/install-slimtoolkit) that walks you through the setup step by step, including pre-flight checks, platform detection, validation and troubleshooting.
+
 ## BASIC USAGE INFO
 
 `mint [global flags] [xray|slim|debug|profile|imagebuild|run|lint|merge|images|registry|vulnerability|app|help] [command-specific flags] <IMAGE_ID_OR_NAME>`


### PR DESCRIPTION
## Summary

- Adds a "Guided Install via KubeStellar Console" subsection under INSTALLATION in the README
- Links to the [guided installation mission](https://console.kubestellar.io/missions/install-slimtoolkit) which provides step-by-step Mint setup with pre-flight checks, platform detection, validation, and troubleshooting

## Context

This mission was developed in collaboration with @kcq on slimtoolkit/slim#844 and kubestellar/console-kb#1536. The guided install uses Mint v1.41.8 and the latest install script as recommended by @kcq.

## Changes

Single addition to `README.md`: a new `### Guided Install via KubeStellar Console` subsection placed after the existing Docker install method and before BASIC USAGE INFO.