### PR TITLE
fix(build): always give go-dockerclient an output stream

### DIFF
--- a/pkg/crt/docker/dockercrtclient/dockercrtclient.go
+++ b/pkg/crt/docker/dockercrtclient/dockercrtclient.go
@@ -106,7 +106,11 @@ func (ref *Instance) BuildImage(options imagebuilder.DockerfileBuildOptions) err
 
 	if options.OutputStream != nil {
 		buildOptions.OutputStream = options.OutputStream
-	} else if ref.showBuildLogs {
+	} else {
+		// go-dockerclient's BuildImage() unconditionally rejects a nil
+		// OutputStream (see vendor/github.com/fsouza/go-dockerclient/image.go,
+		// ErrMissingOutputStream), so a destination must always be provided,
+		// not just when showBuildLogs is requested (mintoolkit/mint#87).
 		ref.buildLog.Reset()
 		buildOptions.OutputStream = &ref.buildLog
 	}

--- a/pkg/crt/docker/dockercrtclient/dockercrtclient.go
+++ b/pkg/crt/docker/dockercrtclient/dockercrtclient.go
@@ -104,14 +104,16 @@ func (ref *Instance) BuildImage(options imagebuilder.DockerfileBuildOptions) err
 		}
 	}
 
+	// go-dockerclient's BuildImage() unconditionally rejects a nil OutputStream
+	// (see vendor/github.com/fsouza/go-dockerclient/image.go,
+	// ErrMissingOutputStream), so a destination must always be provided, not
+	// just when showBuildLogs is requested (mintoolkit/mint#87). The buffer is
+	// reset on every build so BuildOutputLog() can never return the output of
+	// a previous build, including when the caller supplies its own stream.
+	ref.buildLog.Reset()
 	if options.OutputStream != nil {
 		buildOptions.OutputStream = options.OutputStream
 	} else {
-		// go-dockerclient's BuildImage() unconditionally rejects a nil
-		// OutputStream (see vendor/github.com/fsouza/go-dockerclient/image.go,
-		// ErrMissingOutputStream), so a destination must always be provided,
-		// not just when showBuildLogs is requested (mintoolkit/mint#87).
-		ref.buildLog.Reset()
 		buildOptions.OutputStream = &ref.buildLog
 	}
 

--- a/pkg/crt/docker/dockercrtclient/repro_test.go
+++ b/pkg/crt/docker/dockercrtclient/repro_test.go
@@ -1,10 +1,12 @@
 package dockercrtclient
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
 
@@ -21,7 +23,7 @@ import (
 func TestBuildImage_MissingOutputStream_Issue87(t *testing.T) {
 	client, err := docker.NewClientFromEnv()
 	if err != nil {
-		t.Fatalf("docker.NewClientFromEnv: %v", err)
+		t.Skipf("no docker client available, skipping live repro: %v", err)
 	}
 	if err := client.Ping(); err != nil {
 		t.Skipf("no docker daemon reachable, skipping live repro: %v", err)
@@ -36,35 +38,43 @@ func TestBuildImage_MissingOutputStream_Issue87(t *testing.T) {
 		t.Fatalf("write hello.txt: %v", err)
 	}
 
-	b := NewBuilder(client, false) // showBuildLogs=false, matches the user's repro command (no --show-blogs)
+	// Unique per run so the test can never overwrite or delete an image that
+	// happens to exist on the developer's machine, and so parallel runs on the
+	// same daemon don't collide.
+	imageTag := fmt.Sprintf("mint-issue87-repro-%d:test", time.Now().UnixNano())
+
+	b := NewBuilder(client, false) // showBuildLogs=false, matches the report (no --show-blogs)
 
 	opts := imagebuilder.DockerfileBuildOptions{
 		Dockerfile:   "Dockerfile",
 		BuildContext: dir,
-		ImagePath:    "el-mint87-repro:latest",
+		ImagePath:    imageTag,
 		// OutputStream intentionally left nil - this is the exact shape
 		// buildFatImage() in pkg/app/master/command/build/image.go constructs.
 	}
 
 	buildErr := b.BuildImage(opts)
-	defer client.RemoveImage("el-mint87-repro:latest")
+	if buildErr == nil {
+		// Only clean up an image this test actually created.
+		t.Cleanup(func() {
+			if err := client.RemoveImage(imageTag); err != nil {
+				t.Logf("could not remove test image %s: %v", imageTag, err)
+			}
+		})
+	}
 
 	if buildErr != nil {
 		if strings.Contains(buildErr.Error(), "missing output stream") {
-			t.Fatalf("REPRODUCED issue #87: BuildImage failed with %q (options.OutputStream was nil and showBuildLogs=false, "+
-				"so dockercrtclient never set buildOptions.OutputStream, and vendor/github.com/fsouza/go-dockerclient "+
-				"image.go:538-540 rejects the whole build before running anything)", buildErr)
+			t.Fatalf("BuildImage failed with %q: options.OutputStream was nil and showBuildLogs=false, "+
+				"so no output destination was set and go-dockerclient rejected the build before running it", buildErr)
 		}
 		t.Fatalf("BuildImage failed for an unrelated reason: %v", buildErr)
 	}
 
-	// GREEN-path sanity: image must actually exist and the build log must be
-	// non-empty even though showBuildLogs was false (fix always buffers into
-	// ref.buildLog, matching the pattern already used by slimbuilder.go:267).
-	if _, err := client.InspectImage("el-mint87-repro:latest"); err != nil {
+	if _, err := client.InspectImage(imageTag); err != nil {
 		t.Fatalf("image was not built despite BuildImage returning nil error: %v", err)
 	}
 	if b.BuildOutputLog() == "" {
-		t.Fatalf("expected non-empty build log to be captured even with showBuildLogs=false")
+		t.Fatalf("expected the build log to be captured even with showBuildLogs=false")
 	}
 }

--- a/pkg/crt/docker/dockercrtclient/repro_test.go
+++ b/pkg/crt/docker/dockercrtclient/repro_test.go
@@ -1,0 +1,70 @@
+package dockercrtclient
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	docker "github.com/fsouza/go-dockerclient"
+
+	"github.com/mintoolkit/mint/pkg/imagebuilder"
+)
+
+// TestBuildImage_MissingOutputStream_Issue87 reproduces mintoolkit/mint#87
+// ("Missing output stream"): building a Dockerfile-based ("fat") image
+// through the internal build engine (dockercrtclient), WITHOUT passing an
+// explicit OutputStream and WITHOUT --show-blogs (showBuildLogs=false),
+// must not immediately fail with "missing output stream" coming from the
+// vendored fsouza/go-dockerclient BuildImage(), which requires a non-nil
+// OutputStream unconditionally.
+func TestBuildImage_MissingOutputStream_Issue87(t *testing.T) {
+	client, err := docker.NewClientFromEnv()
+	if err != nil {
+		t.Fatalf("docker.NewClientFromEnv: %v", err)
+	}
+	if err := client.Ping(); err != nil {
+		t.Skipf("no docker daemon reachable, skipping live repro: %v", err)
+	}
+
+	dir := t.TempDir()
+	dockerfile := "FROM scratch\nCOPY hello.txt /hello.txt\n"
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write hello.txt: %v", err)
+	}
+
+	b := NewBuilder(client, false) // showBuildLogs=false, matches the user's repro command (no --show-blogs)
+
+	opts := imagebuilder.DockerfileBuildOptions{
+		Dockerfile:   "Dockerfile",
+		BuildContext: dir,
+		ImagePath:    "el-mint87-repro:latest",
+		// OutputStream intentionally left nil - this is the exact shape
+		// buildFatImage() in pkg/app/master/command/build/image.go constructs.
+	}
+
+	buildErr := b.BuildImage(opts)
+	defer client.RemoveImage("el-mint87-repro:latest")
+
+	if buildErr != nil {
+		if strings.Contains(buildErr.Error(), "missing output stream") {
+			t.Fatalf("REPRODUCED issue #87: BuildImage failed with %q (options.OutputStream was nil and showBuildLogs=false, "+
+				"so dockercrtclient never set buildOptions.OutputStream, and vendor/github.com/fsouza/go-dockerclient "+
+				"image.go:538-540 rejects the whole build before running anything)", buildErr)
+		}
+		t.Fatalf("BuildImage failed for an unrelated reason: %v", buildErr)
+	}
+
+	// GREEN-path sanity: image must actually exist and the build log must be
+	// non-empty even though showBuildLogs was false (fix always buffers into
+	// ref.buildLog, matching the pattern already used by slimbuilder.go:267).
+	if _, err := client.InspectImage("el-mint87-repro:latest"); err != nil {
+		t.Fatalf("image was not built despite BuildImage returning nil error: %v", err)
+	}
+	if b.BuildOutputLog() == "" {
+		t.Fatalf("expected non-empty build log to be captured even with showBuildLogs=false")
+	}
+}


### PR DESCRIPTION
Fixes #87.

`mint build` (and `mint slim` building a fat image first) without `--show-blogs` failed immediately with `missing output stream`. `dockercrtclient.BuildImage` only set `buildOptions.OutputStream` when `showBuildLogs` was requested, but the vendored `fsouza/go-dockerclient` rejects a nil `OutputStream` unconditionally (`image.go`, `ErrMissingOutputStream`) — before a single request reaches the daemon.

The fix always buffers the build output into `ref.buildLog`, which is exactly the pattern `slimbuilder.go` already uses for the slim-image build path; `--show-blogs` keeps controlling only whether that buffer is printed afterwards.

The regression test drives the real `BuildImage` against the local Docker daemon (auto-skipped when no daemon is reachable) with the same options shape `buildFatImage` constructs — a nil `OutputStream` and `showBuildLogs=false`. Without the fix it fails with the exact error from the issue; with it, the image builds and the build log is captured. Verified red→green against a live daemon; `go vet` and `gofmt` are clean.
